### PR TITLE
Hotfix: Update mimemagic to pull from github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-# fix for the mimemagic no longer being supported
+# Fix for the mimemagic no longer being supported. Read more: https://github.com/kuru-studio/kuru-studio-social-server/issues/8
 gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'

--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# fix for the mimemagic no longer being supported
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'


### PR DESCRIPTION
# Story Title

[Problem with mimemagic on setting up the server](https://github.com/kuru-studio/kuru-studio-social-server/issues/8)

## Changes made

- Updated `mimemagic` on Gemfile to pull from GitHub directly

## How does the solution address the problem

This PR will solve the problem by pulling `mimemagic` directly from Github so it doesn't matter the versions are being yanked anymore.

## Linked issues

Resolves #8 
