### PR TITLE
Feature: Firebase Authorization Token Expiration

### DIFF
--- a/app/services/firebase_verifier_service.rb
+++ b/app/services/firebase_verifier_service.rb
@@ -28,6 +28,9 @@ class FirebaseVerifierService
     sub = payload['sub']
     raise "Invalid access token. 'Subject' (sub) must be a non-empty string." if sub.nil? || sub.empty?
 
+    exp = payload['exp']
+    raise "Invalid access token. Token has expired." if Time.at(exp) < Time.now
+
     decoded_token
   end
 


### PR DESCRIPTION
# Story Title

Feature: Firebase Authorization Token Expiration

## Changes made

- raise error if token expiration is old

## How does the solution address the problem

This PR will avoid using expired Firebase authorization token.
